### PR TITLE
Fix carousel rotation and visual effects

### DIFF
--- a/script.js
+++ b/script.js
@@ -59,5 +59,5 @@
         });
     }
 
-    setInterval(rotateClasses, 3500);
+    setInterval(rotateClasses, 3000);
 })();

--- a/style.css
+++ b/style.css
@@ -48,17 +48,18 @@ body {
 }
 
 .carousel-img {
-    width: 33%;
+    width: 33.33%;
+    flex: 0 0 33.33%;
     height: 150px;
     object-fit: cover;
     border-radius: 4px;
-    transition: transform 0.5s ease, opacity 0.5s ease;
+    transition: transform 0.5s ease, opacity 0.5s ease, filter 0.5s ease;
 }
 
 .carousel-img.prev,
 .carousel-img.next {
-    transform: scale(0.8);
-    opacity: 0.5;
+    transform: scale(0.9);
+    opacity: 0.4;
     filter: blur(2px);
 }
 


### PR DESCRIPTION
## Summary
- tweak carousel image scaling and opacity
- add flex-basis to keep three images visible
- update auto-rotation interval to 3 seconds

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_6880375f1aec8329959b39ab539d4eda