### PR TITLE
Fix carousel image scaling on mobile

### DIFF
--- a/script.js
+++ b/script.js
@@ -42,37 +42,41 @@
     if (!carousel) return;
 
     const imageFiles = ['1.jpeg', '2.jpeg', '3.jpeg'];
-    const images = [];
+    const items = [];
 
     imageFiles.forEach((file, index) => {
+        const item = document.createElement('div');
+        item.classList.add('carousel-item');
+
+        if (index === 0) {
+            item.classList.add('prev');
+        } else if (index === 1) {
+            item.classList.add('current');
+        } else {
+            item.classList.add('next');
+        }
+
         const img = document.createElement('img');
         img.src = `images/us/${file}`;
         img.alt = `Imagen ${index + 1}`;
         img.classList.add('carousel-img');
 
-        if (index === 0) {
-            img.classList.add('prev');
-        } else if (index === 1) {
-            img.classList.add('current');
-        } else {
-            img.classList.add('next');
-        }
-
-        carousel.appendChild(img);
-        images.push(img);
+        item.appendChild(img);
+        carousel.appendChild(item);
+        items.push(item);
     });
 
     function rotateClasses() {
-        images.forEach(img => {
-            if (img.classList.contains('prev')) {
-                img.classList.remove('prev');
-                img.classList.add('next');
-            } else if (img.classList.contains('current')) {
-                img.classList.remove('current');
-                img.classList.add('prev');
-            } else if (img.classList.contains('next')) {
-                img.classList.remove('next');
-                img.classList.add('current');
+        items.forEach(item => {
+            if (item.classList.contains('prev')) {
+                item.classList.remove('prev');
+                item.classList.add('next');
+            } else if (item.classList.contains('current')) {
+                item.classList.remove('current');
+                item.classList.add('prev');
+            } else if (item.classList.contains('next')) {
+                item.classList.remove('next');
+                item.classList.add('current');
             }
         });
     }

--- a/style.css
+++ b/style.css
@@ -59,23 +59,28 @@ main {
     overflow: hidden;
 }
 
-.carousel-img {
+.carousel-item {
     flex: 0 0 33.33%;
     width: 33.33%;
-    max-width: 100%;
     height: 300px;
+    overflow: hidden;
+}
+
+.carousel-img {
+    width: 100%;
+    height: 100%;
     object-fit: cover;
     border-radius: 4px;
     transition: transform 0.5s ease, opacity 0.5s ease;
 }
 
-.carousel-img.prev,
-.carousel-img.next {
+.carousel-item.prev .carousel-img,
+.carousel-item.next .carousel-img {
     transform: scale(0.9);
     opacity: 0.4;
 }
 
-.carousel-img.current {
+.carousel-item.current .carousel-img {
     transform: scale(1.1);
     opacity: 1;
 }
@@ -179,7 +184,7 @@ main {
         font-size: 1.5rem;
     }
 
-    .carousel-img {
+    .carousel-item {
         height: 300px;
     }
 


### PR DESCRIPTION
## Summary
- ensure carousel images have a constant height
- wrap images in `.carousel-item` containers with overflow hidden
- keep central image enlarged and side images faded

## Testing
- `npm test` *(fails: could not find package.json and network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_688045e260dc83298fe35549e1b8f2af