### PR TITLE
Replace carousel with responsive version

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,7 +18,9 @@
             <p class="signature">Maraitzi y Ángel</p>
             <div class="logo">M♥A</div>
             <p class="tagline">¡Nos vamos a casar!</p>
-            <div class="carousel"></div>
+            <div class="carousel-wrapper">
+                <div class="carousel-track"></div>
+            </div>
             <div id="countdown" class="countdown">
                 <div class="time-box">
                     <span class="days">0</span>

--- a/script.js
+++ b/script.js
@@ -38,43 +38,37 @@
 })();
 
 (function() {
-    const carousel = document.querySelector('.carousel');
-    if (!carousel) return;
+    const track = document.querySelector('.carousel-track');
+    if (!track) return;
 
     const imageFiles = ['1.jpeg', '2.jpeg', '3.jpeg'];
-    const items = [];
+    const images = [];
 
     imageFiles.forEach((file, index) => {
-        const item = document.createElement('div');
-        item.classList.add('carousel-item');
-
         const img = document.createElement('img');
         img.src = `images/us/${file}`;
         img.alt = `Imagen ${index + 1}`;
-        img.classList.add('carousel-img');
-
-        item.appendChild(img);
-        carousel.appendChild(item);
-        items.push(item);
+        track.appendChild(img);
+        images.push(img);
     });
 
     let currentIndex = 0;
 
-    function showIndex(index) {
-        const itemWidth = items[0].getBoundingClientRect().width;
-        carousel.style.transform = `translateX(-${index * itemWidth}px)`;
-        items.forEach((item, idx) => {
-            item.classList.toggle('active', idx === index);
+    function showIndex() {
+        const slideWidth = images[0].getBoundingClientRect().width;
+        track.style.transform = `translateX(-${currentIndex * slideWidth}px)`;
+        images.forEach((img, idx) => {
+            img.classList.toggle('active', idx === currentIndex);
         });
     }
 
     function next() {
-        currentIndex = (currentIndex + 1) % items.length;
-        showIndex(currentIndex);
+        currentIndex = (currentIndex + 1) % images.length;
+        showIndex();
     }
 
-    showIndex(0);
-    setInterval(next, 1500);
+    showIndex();
+    setInterval(next, 3000);
 
-    window.addEventListener('resize', () => showIndex(currentIndex));
+    window.addEventListener('resize', showIndex);
 })();

--- a/style.css
+++ b/style.css
@@ -61,35 +61,32 @@ main {
     margin: 1rem 0 2rem;
 }
 
-.carousel {
-    display: flex;
+.carousel-wrapper {
+    width: 100%;
     overflow: hidden;
+    display: flex;
+    justify-content: center;
     margin-bottom: 1rem;
+}
+
+.carousel-track {
+    display: flex;
     transition: transform 0.6s ease-in-out;
 }
 
-.carousel-item {
-    flex: 0 0 75vw;
+.carousel-track img {
+    width: 75vw;
     height: 300px;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    transition: all 0.6s ease-in-out;
-    opacity: 0.4;
-    filter: blur(1px);
-    transform: scale(0.9);
-}
-
-.carousel-item.active {
-    opacity: 1;
-    filter: none;
-    transform: scale(1.1);
-}
-
-.carousel-img {
-    width: 100%;
-    height: 100%;
     object-fit: cover;
+    flex-shrink: 0;
+    opacity: 0;
+    transform: scale(0.95);
+    transition: opacity 0.6s ease-in-out, transform 0.6s ease-in-out;
+}
+
+.carousel-track img.active {
+    opacity: 1;
+    transform: scale(1);
 }
 
 .countdown {
@@ -215,9 +212,8 @@ main {
         font-size: 1.5rem;
     }
 
-    .carousel-item {
-        flex: 0 0 200px;
-        width: 200px;
+    .carousel-track img {
+        width: 400px;
         height: 300px;
     }
 


### PR DESCRIPTION
## Summary
- update markup to use `carousel-wrapper` and `carousel-track`
- add responsive carousel styles
- implement sliding carousel logic in JS

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6881318153088329863a371f8fa5f1b4