### PR TITLE
Update carousel to stay centered with fade transitions

### DIFF
--- a/style.css
+++ b/style.css
@@ -63,19 +63,20 @@ main {
 
 .carousel-fade {
     position: relative;
+    width: 75vw;
+    max-width: 400px;
     height: 300px;
     overflow: hidden;
-    margin-bottom: 1rem;
+    margin: 0 auto 1rem;
 }
 
 .carousel-fade img {
-    width: 75vw;
-    height: 300px;
-    object-fit: cover;
     position: absolute;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
     top: 0;
-    left: 50%;
-    transform: translateX(-50%);
+    left: 0;
     opacity: 0;
     z-index: 1;
     transition: opacity 0.6s ease-in-out;
@@ -83,7 +84,6 @@ main {
 
 .carousel-fade img.active {
     opacity: 1;
-    position: relative;
     z-index: 2;
 }
 


### PR DESCRIPTION
## Summary
- keep carousel width under 400px
- make images fill the carousel container
- center the carousel and keep fade transition intact

## Testing
- `node -v`


------
https://chatgpt.com/codex/tasks/task_e_68813d3d344c8329b120428eb1ce8bef