### PR TITLE
Add polaroid-style carousel

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,8 +19,8 @@
             <div class="logo">M♥A</div>
             <p class="tagline">¡Nos vamos a casar!</p>
 
-            <!-- Carrusel fade centrado -->
-            <div class="carousel-fade"></div>
+            <!-- Carrusel estilo Polaroid -->
+            <div class="carousel-polaroid"></div>
 
             <div id="countdown" class="countdown">
                 <div class="time-box">

--- a/script.js
+++ b/script.js
@@ -38,16 +38,17 @@
     updateCountdown();
 })();
 
-// Carrusel fade
+// Carrusel estilo Polaroid
 (function () {
-    const container = document.querySelector('.carousel-fade');
+    const container = document.querySelector('.carousel-polaroid');
     if (!container) return;
 
-    const imageFiles = ['1.jpeg', '2.jpeg', '3.jpeg']; // Asegúrate que existan
+    const imageFiles = ['1.jpeg', '2.jpeg', '3.jpeg'];
     const images = [];
 
     imageFiles.forEach((file, index) => {
         const img = document.createElement('img');
+        img.className = 'polaroid-image';
         img.src = `images/us/${file}`;
         img.alt = `Imagen ${index + 1}`;
         container.appendChild(img);
@@ -67,5 +68,5 @@
     setInterval(() => {
         currentIndex = (currentIndex + 1) % images.length;
         showImage(currentIndex);
-    }, 1000); // 1 segundo
+    }, 5000); // 5 segundos
 })();

--- a/style.css
+++ b/style.css
@@ -61,29 +61,32 @@ main {
     margin: 1rem 0 2rem;
 }
 
-.carousel-fade {
+.carousel-polaroid {
     position: relative;
     width: 75vw;
     max-width: 400px;
-    height: 300px;
+    height: 320px;
     overflow: hidden;
     margin: 0 auto 1rem;
 }
 
-.carousel-fade img {
+.polaroid-image {
     position: absolute;
-    width: 100%;
-    height: 100%;
-    object-fit: cover;
-    top: 0;
-    left: 0;
+    top: 50%;
+    left: 50%;
+    width: calc(100% - 40px);
+    transform: translate(-50%, -50%) scale(0.85) rotate(-5deg);
+    background: #fff;
+    padding: 10px 10px 25px;
+    box-shadow: 0 4px 10px rgba(0, 0, 0, 0.3);
     opacity: 0;
+    transition: transform 0.6s ease, opacity 0.6s ease;
     z-index: 1;
-    transition: opacity 0.6s ease-in-out;
 }
 
-.carousel-fade img.active {
+.polaroid-image.active {
     opacity: 1;
+    transform: translate(-50%, -50%) scale(1) rotate(0deg);
     z-index: 2;
 }
 
@@ -210,9 +213,8 @@ main {
         font-size: 1.5rem;
     }
 
-    .carousel-fade img {
-        width: 400px;
-        height: 300px;
+    .polaroid-image {
+        width: calc(100% - 60px);
     }
 
     .time-box span {


### PR DESCRIPTION
## Summary
- replace old image carousel with a new Polaroid-styled version
- update styles for the Polaroid look
- update script logic for new carousel and 5‑second rotation

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_688140236a94832995954b0ef70a424b