### PR TITLE
Improve wedding site countdown

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,6 +40,7 @@
                     <small>segundos</small>
                 </div>
             </div>
+            <p id="countdown-message">💍 ¡Faltan <span id="countdown-dynamic"></span> para nuestra boda! 💍</p>
         </section>
 
         <section class="special-celebration">
@@ -59,6 +60,7 @@
                 <div class="icon">⛪️</div>
                 <h3 class="location-title">CEREMONIA RELIGIOSA</h3>
                 <p class="location-subtitle">Iglesia del Señor del Perdón</p>
+                <p class="event-time">🕐 1:00 PM</p>
                 <p class="location-address">Santa Cruz Teoloyucan</p>
                 <a class="btn-pill" href="https://maps.app.goo.gl/1suh9LqxnP5BCGt69" target="_blank" rel="noopener">Ver ubicación</a>
             </div>
@@ -66,6 +68,7 @@
                 <div class="icon">🥂</div>
                 <h3 class="location-title">RECEPCIÓN</h3>
                 <p class="location-subtitle">Salón de Eventos María Elena</p>
+                <p class="event-time">🕑 2:00 PM</p>
                 <p class="location-address">Santiago, Teoloyucan</p>
                 <a class="btn-pill" href="https://maps.app.goo.gl/UYbRKTfQYB2WSXby8" target="_blank" rel="noopener">Ver ubicación</a>
             </div>

--- a/script.js
+++ b/script.js
@@ -3,6 +3,8 @@
     const countdown = document.getElementById('countdown');
     if (!countdown) return;
 
+    const dynamicEl = document.getElementById('countdown-dynamic');
+
     const daysEl = countdown.querySelector('.days');
     const hoursEl = countdown.querySelector('.hours');
     const minutesEl = countdown.querySelector('.minutes');
@@ -19,6 +21,9 @@
             hoursEl.textContent = 0;
             minutesEl.textContent = 0;
             secondsEl.textContent = 0;
+            if (dynamicEl) {
+                dynamicEl.textContent = '0 días, 0 horas, 0 minutos y 0 segundos';
+            }
             clearInterval(interval);
             return;
         }
@@ -32,6 +37,10 @@
         hoursEl.textContent = hours;
         minutesEl.textContent = minutes;
         secondsEl.textContent = seconds;
+
+        if (dynamicEl) {
+            dynamicEl.textContent = `${days} días, ${hours} horas, ${minutes} minutos y ${seconds} segundos`;
+        }
     }
 
     const interval = setInterval(updateCountdown, 1000);

--- a/style.css
+++ b/style.css
@@ -95,6 +95,10 @@ main {
     justify-content: center;
     gap: 1rem;
 }
+#countdown-message {
+    margin: 1rem 0;
+    font-size: 1rem;
+}
 
 .time-box {
     display: flex;
@@ -186,6 +190,10 @@ main {
     font-size: 1.1rem;
     margin-bottom: 0.25rem;
 }
+.event-time {
+    margin-bottom: 0.25rem;
+    font-weight: 700;
+}
 
 .location-address {
     margin-bottom: 1rem;
@@ -219,6 +227,9 @@ main {
 
     .time-box span {
         font-size: 2rem;
+    }
+    #countdown-message {
+        font-size: 1.25rem;
     }
 
     .special-celebration h2 {


### PR DESCRIPTION
## Summary
- display ceremony and reception times
- add emotional countdown text
- style countdown message and event times

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_688142846f7883299250c50b7d0cdeab